### PR TITLE
changes to install scripts based on FOGL-2965

### DIFF
--- a/extras_install.sh
+++ b/extras_install.sh
@@ -20,14 +20,14 @@
 ## Author: Ori Shadmon 
 ##
 
-set -e
+mkdir /tmp/wind-turbine-install
+cd /tmp/wind-turbine-install
 
-# Apt package
-sudo apt-get install libusb-1.0-0-dev
-
-## extras install
-## ./extras_install
-
-# Python3 specific prerequisites - https://www.phidgets.com/docs/Language_-_Python 
-pip3 install -Ir python/requirements-wind_turbine.txt --no-cache-dir
-
+# Linux specific prerequisites - https://www.phidgets.com/docs/OS_-_Linux
+wget https://www.phidgets.com/downloads/phidget22/libraries/linux/libphidget22.tar.gz
+tar -xzvf /tmp/wind-turbine-install/libphidget22.tar.gz
+cd /tmp/wind-turbine-install/libphidget22-*
+./configure --prefix=/ && make && sudo make install
+fn=`find -name *libphidget22.rule*`
+sudo mv ${fn} /etc/udev/rules.d.
+sudo rm -rf /tmp/wind-turbine-install

--- a/requirements.sh
+++ b/requirements.sh
@@ -26,8 +26,7 @@ set -e
 sudo apt-get install libusb-1.0-0-dev
 
 ## extras install
-## ./extras_install
+./extras_install.sh
 
 # Python3 specific prerequisites - https://www.phidgets.com/docs/Language_-_Python 
 pip3 install -Ir python/requirements-wind_turbine.txt --no-cache-dir
-


### PR DESCRIPTION
Broke-down `requirements.sh` to `requirements.sh` and `extras_install.sh`  based on [FOGL-2965](https://scaledb.atlassian.net/browse/FOGL-2965).  